### PR TITLE
Adding PyDev files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.swp
 *.idea
 *.project
+*.pydevproject
 *.kpf
 
 # Don't store secret keys in version control


### PR DESCRIPTION
If we're going to ignore .project files in the included .gitignore, we may as well ignore .pydevproject files (created when you use PyDev, which most people who are using Eclipse will be doing) too.
