### PR TITLE
Minor viewport tag tweak

### DIFF
--- a/src/application/templates/base.html
+++ b/src/application/templates/base.html
@@ -2,7 +2,7 @@
 <html lang="en" class="no-js">
 <head>
 	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width; initial-scale=1.0;" />
+	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
 	<title>{% block title %}Examples{% endblock %}</title>
 	<link rel="shortcut icon" href="/favicon.ico" />


### PR DESCRIPTION
The error console in Chrome (17.0.963.2 dev) complains that:

```
Viewport argument value "device-width;" for key "width" not recognized. Content ignored.
Viewport argument value "1.0;" for key "initial-scale" was truncated to its numeric prefix.
```

Switching to this line matching what Mozilla recommends at https://developer.mozilla.org/en/Mobile/Viewport_meta_tag silences the complaints (and presumably causes the width to be honored, though I haven't tested that on mobile).

PS - your project is super-useful, thanks!
