### PR TITLE
BUGFIX: Fix ``admin_required`` decorator to not redirect connected users with  no admin credentials in infinite loop.

### DIFF
--- a/src/application/decorators.py
+++ b/src/application/decorators.py
@@ -7,7 +7,7 @@ Decorators for URL handlers
 
 from functools import wraps
 from google.appengine.api import users
-from flask import redirect, request
+from flask import redirect, request, abort
 
 
 def login_required(func):
@@ -24,8 +24,9 @@ def admin_required(func):
     """Requires App Engine admin credentials"""
     @wraps(func)
     def decorated_view(*args, **kwargs):
-        if not users.is_current_user_admin():
-            return redirect(users.create_login_url(request.url))
-        return func(*args, **kwargs)
+        if users.get_current_user():
+            if not users.is_current_user_admin():
+                abort(401)  # Unauthorized
+            return func(*args, **kwargs)
+        return redirect(users.create_login_url(request.url))
     return decorated_view
-


### PR DESCRIPTION
Hi,

First of all, i want to thanks all the responsible for this great project, it was very helpful to me and to make it more so, allow me to make my contribution, hopefully it will be helpful to someone other than me.
### Description:

When a **logged in** user with **no admin** credentials try to access a URL which **require admin credential**, the user will be trapped in an infinite loop of redirects. 
### How to reproduce:
- First of all you need to be **in production** environment.
- Logged in using a user with **no admin** credentials.
- Try now to access an URL that require **admin credentials**.
- You should see now that you are trapped in a loop of infinite redirect.
### My fix:

The new code is simple, basically it only redirect not logged in users to the login URL:

```
if users.get_current_user(): 
    if not users.is_current_user_admin():
         abort(401) 
    return func(*args, **kwargs)
return redirect(users.create_login_url(request.url))
```
### Drawbacks:

One drawback of this new code, is that in development environment, if you are already logged in with no admin user and you try to access an admin page you will have to logged out before you can try again. 

HTH,
## 

mouad
