### PR TITLE
Removing an artefact due to the modal dialog

### DIFF
--- a/src/application/templates/list_examples.html
+++ b/src/application/templates/list_examples.html
@@ -8,6 +8,7 @@
 
 {% block content %}
 
+
     <h1 id="">All Examples</h1>
     <div>&nbsp;</div>
     <table class="table table-bordered table-striped">
@@ -81,8 +82,6 @@
             }
         };
         $(document).ready(function() {
-            // Enable modal dialog (via Bootstrap's 'modal' plugin)
-            $('#new-example-modal').modal({'show': false});
             FormHelpers.init();
         });
     </script>

--- a/src/application/templates/new_example.html
+++ b/src/application/templates/new_example.html
@@ -1,6 +1,6 @@
-<div class="modal fade" id="new-example-modal">
+<div class="modal hide fade" id="new-example-modal">
     <div class="modal-header">
-        <button class="close" data-dismiss="modal">×</button>
+        <button class="close" data-dismiss="modal">&times;</button>
         <h3>Add a New Example</h3>
     </div>
     <div class="modal-body">


### PR DESCRIPTION
On first loading the example application, the rightmost three menu items are hidden, the ones leading to Appengine, Bootstrap, and Flask docs. When the app starts up, they are hidden behind the invisible dialog box for some reason! This patch resolves that issue.
