### PR TITLE
Update generate_keys.py to fix an error with range(length)

### DIFF
--- a/src/application/generate_keys.py
+++ b/src/application/generate_keys.py
@@ -49,7 +49,7 @@ parser.add_option(
 def generate_randomkey(length):
     """Generate random key, given a number of characters"""
     chars = string.letters + string.digits
-    return ''.join([choice(chars) for i in range(length)])
+    return ''.join([choice(chars) for i in range(int(length))])
 
 
 def write_file(contents):


### PR DESCRIPTION
Convert length to int to prevent TypeError: range() integer end argument expected, got str.